### PR TITLE
Adding 'put package in stash' function

### DIFF
--- a/src/app/Http/Middleware/EnsureRole.php
+++ b/src/app/Http/Middleware/EnsureRole.php
@@ -12,9 +12,9 @@ class EnsureRole
     {
         $user = Auth::user();
 
-        // if (!$user || !in_array($user->staff->staff_type, $roles)) {
-        //     return redirect()->route('dashboard')->with('auth_required', 'You do not have permission to access this area.');
-        // }
+        if (!$user || !in_array($user->staff->staff_type, $roles)) {
+            return redirect()->route('dashboard')->with('auth_required', 'You do not have permission to access this area.');
+        }
 
         return $next($request);
     }

--- a/src/app/Http/Middleware/EnsureRole.php
+++ b/src/app/Http/Middleware/EnsureRole.php
@@ -12,9 +12,9 @@ class EnsureRole
     {
         $user = Auth::user();
 
-        if (!$user || !in_array($user->staff->staff_type, $roles)) {
-            return redirect()->route('dashboard')->with('auth_required', 'You do not have permission to access this area.');
-        }
+        // if (!$user || !in_array($user->staff->staff_type, $roles)) {
+        //     return redirect()->route('dashboard')->with('auth_required', 'You do not have permission to access this area.');
+        // }
 
         return $next($request);
     }

--- a/src/resources/views/layouts/public.blade.php
+++ b/src/resources/views/layouts/public.blade.php
@@ -30,6 +30,7 @@
                 <a href="{{ route('public.postmats.index') }}" class="text-gray-700 hover:text-blue-600 transition">Browse Postmats</a>
                 <a href="{{ route('client.send_package') }}" class="text-gray-700 hover:text-blue-600 transition">Send a parcel</a>
                 <a href="{{ route('client.collect_package') }}" class="text-gray-700 hover:text-blue-600 transition">Collect a parcel</a>
+                <a href="{{ route('client.packages') }}" class="text-gray-700 hover:text-blue-600 transition">Your parcels</a>
                 @auth
                     <form action="{{ route('logout') }}" method="POST" class="inline">
                         @csrf

--- a/src/resources/views/public/client/packages/index.blade.php
+++ b/src/resources/views/public/client/packages/index.blade.php
@@ -1,0 +1,74 @@
+@extends('layouts.public')
+
+@section('content')
+    <div class="max-w-7xl mx-auto py-10 px-4 sm:px-6 lg:px-8">
+        <h1 class="text-3xl font-bold text-gray-800 mb-6">Your Sent Packages</h1>
+
+        @if (session('error'))
+            <div class="mb-4 p-4 bg-red-100 border border-red-300 text-red-800 rounded-lg">
+                {{ session('error') }}
+            </div>
+        @endif
+
+        @if (session('success'))
+            <div class="mb-4 p-4 bg-green-100 border border-green-300 text-green-800 rounded-lg">
+                {{ session('success') }}
+            </div>
+        @endif
+
+
+        @if ($packages->isEmpty())
+            <div class="bg-yellow-100 text-yellow-800 p-4 rounded-lg">
+                You have not sent any packages yet.
+            </div>
+        @else
+            <div class="overflow-x-auto bg-white shadow-md rounded-lg">
+                <table class="min-w-full table-auto text-sm text-left text-gray-600">
+                    <thead class="bg-blue-500 text-xs font-semibold uppercase tracking-wider text-white">
+                        <tr>
+                            <th class="px-6 py-4">ID</th>
+                            <th class="px-6 py-4">Status</th>
+                            <th class="px-6 py-4">Size</th>
+                            <th class="px-6 py-4">Weight (g)</th>
+                            <th class="px-6 py-4">To Postmat</th>
+                            <th class="px-6 py-4">Created</th>
+                            <th class="px-6 py-4">Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody class="divide-y divide-gray-200">
+                        @foreach ($packages as $package)
+                            <tr>
+                                <td class="px-6 py-4">{{ $package->id }}</td>
+                                <td class="px-6 py-4 capitalize">{{ $package->status }}</td>
+                                <td class="px-6 py-4">{{ $package->size }}</td>
+                                <td class="px-6 py-4">{{ $package->weight }}</td>
+                                <td class="px-6 py-4">
+                                    {{ optional($package->destinationPostmat)->name ?? 'N/A' }}
+                                </td>
+                                <td class="px-6 py-4">{{ $package->created_at->format('Y-m-d') }}</td>
+                                <td class="px-6 py-4">
+                                    @if ($package->status === 'registered')
+                                        {{-- POST: put_package_in_postmat --}}
+                                        <form action="{{ route('client.put_package_in_postmat') }}" method="POST"
+                                            class="inline">
+                                            @csrf
+                                            <input type="hidden" name="package_id" value="{{ $package->id }}">
+                                            <button type="submit" class="text-green-600 hover:text-green-800 font-medium">
+                                                Open Stash
+                                            </button>
+                                        </form>
+                                    @else
+                                        <a href="{{ route('package.lookup') . '?code=' . $package->id }}"
+                                            class="text-indigo-600 hover:text-indigo-900 font-medium">
+                                            Track
+                                        </a>
+                                    @endif
+                                </td>
+                            </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            </div>
+        @endif
+    </div>
+@endsection

--- a/src/resources/views/public/client/packages/package_summary.blade.php
+++ b/src/resources/views/public/client/packages/package_summary.blade.php
@@ -135,6 +135,7 @@
                         class="w-48 h-48 border p-2 rounded-lg">
                     <p class="mt-2 text-sm text-gray-500">  Scan this QR code to track your package, or access the tracking page using the link below.</p>
                     <a href="{{ $trackUrl }}" class="text-blue-500 mt-2">{{ $trackUrl }}</a>
+                    <p class="mt-2 text-sm text-gray-500">To put package in stash go to: <a href="{{ route('client.packages') }}" class="text-blue-500">Your parcels</a></p>
                 </div>
 
                 <!-- Actions -->

--- a/src/resources/views/public/client/packages/package_track.blade.php
+++ b/src/resources/views/public/client/packages/package_track.blade.php
@@ -22,6 +22,9 @@
                                 Reciever Phone: <strong>{{ $maskedPhone }}</strong>
                             </p>
                         @endif
+                        <p class="text-gray-700 text-md">
+                            Package status: <strong>{{ $package->status }}</strong>
+                        </p>
                     </div>
                 @endif
 
@@ -88,7 +91,7 @@
                     .addTo(map)
                     .bindPopup(
                         "<strong>{{ $postmat->name }}</strong><br>{{ $postmat->city }}, {{ $postmat->{'post-code'} }}"
-                        )
+                    )
                     .openPopup();
             });
         </script>

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -69,8 +69,10 @@ Route::prefix('warehouse')->middleware(['auth', 'verified', 'role:warehouse'])->
 
 // Client routes
 Route::middleware(['auth', 'verified'])->group(function () {
+    Route::get('/client/packages/', [App\Http\Controllers\Client\PackageController::class, 'show_user_packages'])->name('client.packages');
     Route::get('/client/packages/send_package', [App\Http\Controllers\Client\PackageController::class, 'showForm'])->name('client.send_package');
     Route::post('/client/packages/send_package', [App\Http\Controllers\Client\PackageController::class, 'send_package'])->name('client.send_package.submit');
+    Route::post('/client/packages/put_package_in_postmat', [App\Http\Controllers\Client\PackageController::class, 'put_package_in_postmat'])->name('client.put_package_in_postmat');
 });
 
 Route::get('/track', [App\Http\Controllers\Client\PackageController::class, 'track'])->name('package.lookup');


### PR DESCRIPTION
## Logic of this function
When a user creates a package in our database, it is stored with status = 'registered'.

![](https://github.com/user-attachments/assets/cc6849ea-59e9-4794-bbf2-2973afc6094f)

In the Your parcels view, the user can change the status label to In transit.

### Before pressing 'Open stash':
![](https://github.com/user-attachments/assets/084d27d1-036c-41bc-baf0-7bc1288afcc9)
![](https://github.com/user-attachments/assets/06845d0c-1ed7-450b-a9e7-3318e12f229c)
![](https://github.com/user-attachments/assets/66a4683e-5daa-486e-a9e7-088e2a75a511)

### After pressing 'Open stash' button:
![](https://github.com/user-attachments/assets/23b32967-2494-4edf-9d69-b569bdb2093f)
![](https://github.com/user-attachments/assets/198ad730-0c1a-4ef6-afcd-62c09bb7516c)
![](https://github.com/user-attachments/assets/f5bec08f-cb88-4d72-9e3e-d7023f12cf84)

### Maintaining code
Inside this function we can also log a tracking event so the timeline shows that the user has put the package into the stash.

```php
        // Do everything atomically
        DB::transaction(function () use ($package, $stash) {
            // 1. Update status of package
            $package->update(['status' => 'in_transit']);

            // 2. Confirm reservation of package.
            $stash->update(['is_package_in' => true]);

            // 3. add tracking event
            // Actualization::create([
            //     'package_id' => $package->id,
            //     'message'    => 'in_transit',
            // ]);
        });
```